### PR TITLE
Migrate from master-slave words

### DIFF
--- a/Backend/BackendController/tasks/install_stack.py
+++ b/Backend/BackendController/tasks/install_stack.py
@@ -702,12 +702,12 @@ def ReplicateHAProxyFiles(insert_id = 0):
             #CreateFTPAccount(send_async_request['ftp'])
 
 
-        sendNotification(get_server.user_id.id, 'toast', 'success', "File Replicated" , 'File is Replicated to all node servers of master ' + get_server.server_name + '  (' + get_server.server_ip + ').')
+        sendNotification(get_server.user_id.id, 'toast', 'success', "File Replicated" , 'File is Replicated to all node servers of main ' + get_server.server_name + '  (' + get_server.server_ip + ').')
         inse_id.status = "Configured"
         inse_id.save()
 
     except Exception as e:
         print(e)
         traceback.print_exc(limit=1, file=sys.stdout)
-        sendNotification(get_server.user_id.id, 'toast', 'error', ' Error Ocurred', 'Domains is not Replicated to all node servers of master ' + get_server.server_name + '  (' + get_server.server_ip + ').')    
+        sendNotification(get_server.user_id.id, 'toast', 'error', ' Error Ocurred', 'Domains is not Replicated to all node servers of main ' + get_server.server_name + '  (' + get_server.server_ip + ').')    
         #inse_id.delete()


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.